### PR TITLE
fix(tree-sitter): remove buffer in ts_parser_parse

### DIFF
--- a/packages/tree-sitter-capi/src/TreeSitter/CApi.hsc
+++ b/packages/tree-sitter-capi/src/TreeSitter/CApi.hsc
@@ -499,7 +499,6 @@ foreign import ccall "wrapper"
 foreign import capi unsafe "TreeSitter/CApi_hsc.h _wrap_ts_input_new"
   _wrap_ts_input_new ::
     FunPtr TSRead ->
-    ( #{type size_t} ) ->
     TSInputEncoding ->
     IO (Ptr TSInput)
 
@@ -520,7 +519,6 @@ foreign import capi unsafe "TreeSitter/CApi_hsc.h _wrap_ts_input_new"
 #{def
   TSInput *_wrap_ts_input_new(
     TSRead read,
-    size_t buffer_size,
     TSInputEncoding encoding
   ) {
     TSInput *input = malloc(sizeof *input);
@@ -1157,12 +1155,11 @@ ts_parser_parse ::
   Ptr TSParser ->
   ConstPtr TSTree ->
   TSRead ->
-  ( #{type size_t} ) ->
   TSInputEncoding ->
   IO (Ptr TSTree)
-ts_parser_parse = \self old_tree readFun buffer_size encoding ->
+ts_parser_parse = \self old_tree readFun encoding ->
   bracket (mkTSReadFunPtr readFun) freeHaskellFunPtr $ \readFun_p ->
-    bracket (_wrap_ts_input_new readFun_p buffer_size encoding) _wrap_ts_input_delete $ \input_p ->
+    bracket (_wrap_ts_input_new readFun_p encoding) _wrap_ts_input_delete $ \input_p ->
       _wrap_ts_parser_parse self old_tree input_p
 
 foreign import capi safe "TreeSitter/CApi_hsc.h _wrap_ts_parser_parse"

--- a/packages/tree-sitter-capi/src/TreeSitter/CApi.hsc
+++ b/packages/tree-sitter-capi/src/TreeSitter/CApi.hsc
@@ -471,33 +471,27 @@ data
 
 {-| The type of the @`read`@ argument of the @`_wrap_ts_input_new`@ function.
 
-  > typedef void (*TSRead)(
+  > typedef const char *(*TSRead)(
   >   uint32_t byte_index,
   >   TSPoint *position,
-  >   uint32_t *bytes_read,
-  >   size_t buffer_size,
-  >   char *buffer
+  >   uint32_t *bytes_read
   > );
   -}
 type TSRead =
   ( #{type uint32_t} ) ->
   Ptr TSPoint ->
   Ptr ( #{type uint32_t} ) ->
-  ( #{type size_t} ) ->
-  Ptr CChar ->
-  IO ()
+  IO (ConstPtr CChar)
 
 -- | Convert a Haskell 'TSRead' closure to a C 'TSRead' function pointer.
 foreign import ccall "wrapper"
   mkTSReadFunPtr :: TSRead -> IO (FunPtr TSRead)
 
 #{def
-  typedef void (*TSRead)(
+  typedef const char *(*TSRead)(
     uint32_t byte_index,
     TSPoint *position,
-    uint32_t *bytes_read,
-    size_t buffer_size,
-    char *buffer
+    uint32_t *bytes_read
   );
 }
 
@@ -510,18 +504,28 @@ foreign import capi unsafe "TreeSitter/CApi_hsc.h _wrap_ts_input_new"
     IO (Ptr TSInput)
 
 #{def
+  const char *_wrap_ts_input_read(
+    void *payload,
+    uint32_t byte_index,
+    TSPoint position,
+    uint32_t *bytes_read
+  ) {
+    TSRead read;
+    memcpy(&read, payload, sizeof read);
+    TSPoint *position_p = &position;
+    return read(byte_index, position_p, bytes_read);
+  }
+}
+
+#{def
   TSInput *_wrap_ts_input_new(
     TSRead read,
     size_t buffer_size,
     TSInputEncoding encoding
   ) {
-    TSPayload *payload = malloc(sizeof(TSPayload) + buffer_size);
-    payload->callback = read;
-    payload->buffer_size = buffer_size;
-    payload->buffer[0] = 0;
-
     TSInput *input = malloc(sizeof *input);
-    input->payload = payload;
+    input->payload = malloc(sizeof read);
+    memcpy(input->payload, &read, sizeof read);
     input->read = _wrap_ts_input_read;
     input->encoding = encoding;
     return input;
@@ -540,28 +544,6 @@ foreign import capi unsafe "TreeSitter/CApi_hsc.h _wrap_ts_input_delete"
   ) {
     free(input->payload);
     free(input);
-  }
-}
-
-#{def
-  typedef struct {
-    TSRead callback;
-    size_t buffer_size;
-    char buffer[];
-  } TSPayload;
-}
-
-#{def
-  const char *_wrap_ts_input_read(
-    void *payload_p,
-    uint32_t byte_index,
-    TSPoint position,
-    uint32_t *bytes_read
-  ) {
-    TSPayload *payload = payload_p;
-    TSRead read = payload->callback;
-    read(byte_index, &position, bytes_read, payload->buffer_size, payload->buffer);
-    return payload->buffer;
   }
 }
 

--- a/packages/tree-sitter/src/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/src/TreeSitter/Internal.hs
@@ -651,10 +651,12 @@ parserParse parser oldTree input encoding =
     withMaybeTreeAsTSTreePtr oldTree $ \oldTreePtr -> do
       -- NOTE: The purpose of `chunkRef` is to hold on to a reference to
       --       the current chunk and prevent its garbage collection until
-      --       the next call to `tsRead`. Incorrect management of these
-      --       references will cause either a memory leak or a use-after-free
-      --       error, since by using `unsafeForeignPtrToPtr` we circumvent the
-      --       foreign pointer finalizer.
+      --       the next call to `tsRead`.
+      --       Incorrect management of these references can potentially cause
+      --       either a memory leak or a use-after-free error, since by using
+      --       `unsafeForeignPtrToPtr` we bypass the foreign pointer finalizer.
+      -- NOTE: Despite my best efforts, I have not been able to demonstrate
+      --       that this code without the `IORef` leaks memory.
       chunkRef <- newIORef BS.empty
       let tsRead = \byteIndex position_p bytesRead -> do
             position <- WrapTSPoint <$> peek position_p

--- a/packages/tree-sitter/src/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/src/TreeSitter/Internal.hs
@@ -227,6 +227,7 @@ import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Internal (ByteString (BS))
 import Data.ByteString.Unsafe qualified as BSU
 import Data.Coerce (coerce)
+import Data.IORef (newIORef, writeIORef)
 import Data.Maybe (isJust)
 import Foreign
 import Foreign.C (CBool, CInt (CInt), CSize (..))
@@ -237,7 +238,6 @@ import GHC.IO.Handle.FD (handleToFd)
 import System.IO (Handle)
 import TreeSitter.CApi qualified as C
 import TreeSitter.CApi qualified as TSNode (TSNode (..))
-import Data.IORef (newIORef, writeIORef)
 
 --------------------------------------------------------------------------------
 
@@ -627,8 +627,6 @@ parserRemoveLogger :: Parser -> IO (Maybe Log)
 parserRemoveLogger parser =
   withParserAsTSParserPtr parser $
     fmap (fmap tsLogToLog) . C.ts_parser_remove_logger . coerce
-
-
 
 inputToTSRead :: Input -> C.TSRead
 inputToTSRead input = \byteIndex position_p bytesRead -> do

--- a/packages/tree-sitter/src/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/src/TreeSitter/Internal.hs
@@ -222,9 +222,9 @@ module TreeSitter.Internal (
 import Control.Exception (Exception (..), assert, bracket, throwIO)
 import Control.Monad ((<=<))
 import Data.ByteString qualified as BS
-import Data.ByteString.Internal (ByteString (BS))
 import Data.ByteString.Builder qualified as BSB
 import Data.ByteString.Char8 qualified as BSC
+import Data.ByteString.Internal (ByteString (BS))
 import Data.ByteString.Unsafe qualified as BSU
 import Data.Coerce (coerce)
 import Data.Maybe (isJust)
@@ -644,8 +644,8 @@ parserRemoveLogger parser =
     fmap (fmap tsLogToLog) . C.ts_parser_remove_logger . coerce
 
 -- | See @`C.ts_parser_parse`@.
-parserParse :: Parser -> Maybe Tree -> Input -> Word64 -> InputEncoding -> IO (Maybe Tree)
-parserParse parser oldTree input bufferSize encoding =
+parserParse :: Parser -> Maybe Tree -> Input -> InputEncoding -> IO (Maybe Tree)
+parserParse parser oldTree input encoding =
   withParserAsTSParserPtr parser $ \parserPtr ->
     withMaybeTreeAsTSTreePtr oldTree $ \oldTreePtr -> do
       newTreePtr <-
@@ -653,7 +653,6 @@ parserParse parser oldTree input bufferSize encoding =
           parserPtr
           (ConstPtr oldTreePtr)
           (inputToTSRead input)
-          bufferSize
           (coerce encoding)
       toMaybeTree newTreePtr
 

--- a/packages/tree-sitter/test/Test/TreeSitter/Corpus.hs
+++ b/packages/tree-sitter/test/Test/TreeSitter/Corpus.hs
@@ -24,6 +24,12 @@ import TreeSitter.SExp (
   prettySExpDiff,
  )
 
+-- TODO: makeCorpusTest should read the file as a ByteString in order
+--       to preserve whatever encoding is present
+-- TODO: makeCorpusTest should store the position in the file, rather
+--       than the entire string, in order to lower memory consumption
+--       in the test suite
+
 makeCorpusTests :: IO (ConstPtr tsLanguage) -> FilePath -> IO [TestTree]
 makeCorpusTests languageConstructor corpusDirectory = do
   corpusFiles <- Glob.globDir1 "**/*.txt" corpusDirectory

--- a/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
@@ -180,7 +180,7 @@ test_parseJQuery = do
         input byteIndex _position = do
           let start = fromIntegral byteIndex
           let chunk = BS.take 4096 (BS.drop (start - 1) jQueryContent)
-          -- NOTE: Copy the chunk to 
+          -- NOTE: copy the chunk to ensure it has its own memory (to leak)
           pure $ BS.copy chunk
     for_ [1..1000] $ \(_time :: Int) -> do
       maybeTree <- TS.parserParse parser Nothing input TS.InputEncodingUTF8

--- a/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
@@ -156,7 +156,7 @@ test_parserParse =
         input byteIndex _position = do
           let start = fromIntegral byteIndex - 1
           pure $ BS.take 2 (BS.drop start program)
-    maybeTree <- TS.parserParse parser Nothing input 1 TS.InputEncodingUTF8
+    maybeTree <- TS.parserParse parser Nothing input TS.InputEncodingUTF8
     tree <- maybe (assertFailure "failed to parse the program") pure maybeTree
     rootNode <- TS.treeRootNode tree
     rootNodeString <- TS.showNodeAsString rootNode

--- a/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
@@ -26,6 +26,7 @@ import TreeSitter qualified as TS
 import TreeSitter.JavaScript (tree_sitter_javascript)
 import TreeSitter.While (tree_sitter_while)
 import Data.Foldable (for_)
+import System.Mem (performMajorGC, performMinorGC)
 
 tests :: TestTree
 tests =
@@ -178,6 +179,7 @@ test_parseJQuery = do
     jQueryContent <- BS.readFile jQueryFile
     let input :: TS.Input
         input byteIndex _position = do
+          performMinorGC
           let start = fromIntegral byteIndex
           let chunk = BS.take 4096 (BS.drop (start - 1) jQueryContent)
           -- NOTE: copy the chunk to ensure it has its own memory (to leak)
@@ -188,3 +190,4 @@ test_parseJQuery = do
       rootNode <- TS.treeRootNode tree
       rootNodeString <- TS.showNodeAsString rootNode
       assertBool "rootNode string is empty" (not . null $ rootNodeString)
+      performMajorGC

--- a/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
@@ -8,6 +8,7 @@ import Control.Monad (unless)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as BSC
+import Data.Foldable (for_)
 import Data.GraphViz.Commands (GraphvizOutput (..), runGraphviz)
 import Data.GraphViz.Types (parseDotGraph)
 import Data.GraphViz.Types.Generalised (DotGraph)
@@ -20,13 +21,12 @@ import System.Directory (doesFileExist)
 import System.FilePath ((</>))
 import System.IO (IOMode (..), withFile)
 import System.IO.Temp (withSystemTempDirectory)
+import System.Mem (performMajorGC, performMinorGC)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
 import TreeSitter qualified as TS
 import TreeSitter.JavaScript (tree_sitter_javascript)
 import TreeSitter.While (tree_sitter_while)
-import Data.Foldable (for_)
-import System.Mem (performMajorGC, performMinorGC)
 
 tests :: TestTree
 tests =
@@ -184,7 +184,7 @@ test_parseJQuery = do
           let chunk = BS.take 4096 (BS.drop (start - 1) jQueryContent)
           -- NOTE: copy the chunk to ensure it has its own memory (to leak)
           pure $ BS.copy chunk
-    for_ [1..1000] $ \(_time :: Int) -> do
+    for_ [1 .. 1000] $ \(_time :: Int) -> do
       maybeTree <- TS.parserParse parser Nothing input TS.InputEncodingUTF8
       tree <- maybe (assertFailure "failed to parse the program") pure maybeTree
       rootNode <- TS.treeRootNode tree

--- a/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
+++ b/packages/tree-sitter/test/Test/TreeSitter/Internal.hs
@@ -153,10 +153,9 @@ test_parserParse =
             , "y := x + 1"
             ]
     let input :: TS.Input
-        input byteIndex _position bufferSize = do
-          let start = fromIntegral byteIndex
-          let stop = fromIntegral bufferSize
-          pure $ BS.take stop (BS.drop (start - 1) program)
+        input byteIndex _position = do
+          let start = fromIntegral byteIndex - 1
+          pure $ BS.take 2 (BS.drop start program)
     maybeTree <- TS.parserParse parser Nothing input 1 TS.InputEncodingUTF8
     tree <- maybe (assertFailure "failed to parse the program") pure maybeTree
     rootNode <- TS.treeRootNode tree

--- a/packages/tree-sitter/tree-sitter.cabal
+++ b/packages/tree-sitter/tree-sitter.cabal
@@ -57,6 +57,7 @@ library tree-sitter-corpus
 test-suite tree-sitter-test
   import:          language
   type:            exitcode-stdio-1.0
+  ghc-options:     -rtsopts
   hs-source-dirs:  test
   main-is:         Main.hs
   autogen-modules: Paths_tree_sitter

--- a/packages/tree-sitter/tree-sitter.cabal
+++ b/packages/tree-sitter/tree-sitter.cabal
@@ -57,6 +57,7 @@ library tree-sitter-corpus
 test-suite tree-sitter-test
   import:          language
   type:            exitcode-stdio-1.0
+  ghc-options:     +RTS -M128m -RTS
   hs-source-dirs:  test
   main-is:         Main.hs
   autogen-modules: Paths_tree_sitter

--- a/packages/tree-sitter/tree-sitter.cabal
+++ b/packages/tree-sitter/tree-sitter.cabal
@@ -57,7 +57,6 @@ library tree-sitter-corpus
 test-suite tree-sitter-test
   import:          language
   type:            exitcode-stdio-1.0
-  ghc-options:     +RTS -M128m -RTS
   hs-source-dirs:  test
   main-is:         Main.hs
   autogen-modules: Paths_tree_sitter


### PR DESCRIPTION
This PR removes the internal buffer. However, this requires some amount of consideration, since this is only safe if the returned `ByteString` outlives the call to the `input` callback.

NOTE: This PR certainly has both a memory leak and a use-after-free error, which can be solved by storing a reference to the latest chunk in an `MVar` in `ts_parser_parse`. However, it might be best to first write a test that _detects_ such errors, since the current test suite is clearly inadequate.